### PR TITLE
Fix accent encoding in project description

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,11 +1,11 @@
-﻿[build-system]
+[build-system]
 requires = ["setuptools>=69", "wheel"]
 build-backend = "setuptools.build_meta"
 
 [project]
 name = "concatenator"
 version = "1.0.5"
-description = "Outil graphique pour concatÃ©ner des fichiers texte (PySide6)"
+description = "Outil graphique pour concaténer des fichiers texte (PySide6)"
 readme = "README.md"
 requires-python = ">=3.9"
 authors = [{ name = "Daniel", email = "sanz.daniel95@gmail.com" }]


### PR DESCRIPTION
## Summary
- correct description in `pyproject.toml` from `concatÃ©ner` to `concaténer`
- ensure `pyproject.toml` is UTF-8 encoded without BOM

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689cd19ea1c4833191acf6fec2fd126b